### PR TITLE
Remove outdated installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ A Neovim plugin for Textual CSS (.tcss) syntax highlighting as seen on [transcen
 ```lua
 use {
     'cachebag/nvim-tcss',
-    build = "npm install",
     config = function()
         require('tcss').setup()
     end
@@ -31,14 +30,13 @@ use {
 ```lua
 {
     'cachebag/nvim-tcss',
-    build = "npm install",
     config = true
 }
 ```
 
 ### Using [vim-plug](https://github.com/junegunn/vim-plug)
 ```vim
-Plug 'cachebag/nvim-tcss', { 'do': 'npm install' }
+Plug 'cachebag/nvim-tcss'
 
 " After installation, in your init.vim/init.lua:
 lua require('tcss').setup()
@@ -46,19 +44,18 @@ lua require('tcss').setup()
 
 ### Using [dein.vim](https://github.com/Shougo/dein.vim)
 ```vim
-call dein#add('cachebag/nvim-tcss', {'build': 'npm install'})
+call dein#add('cachebag/nvim-tcss')
 ```
 
 ### Using [minpac](https://github.com/k-takata/minpac)
 ```vim
-call minpac#add('cachebag/nvim-tcss', {'do': 'npm install'})
+call minpac#add('cachebag/nvim-tcss')
 ```
 
 ### Using [vim-pathogen](https://github.com/tpope/vim-pathogen)
 ```bash
 cd ~/.vim/bundle
 git clone https://github.com/cachebag/nvim-tcss.git
-cd ~/.vim/bundle/nvim-tcss && npm install
 ```
 
 ## Configuration


### PR DESCRIPTION
Hey! I was going to install your plugin, but I believe there's a problem with the installation instructions. All of the package managers specify that you need to include `npm install` as a build step, however there's no `package.json` in the repository which causes installation to fail. I'm not sure if this is an old remnant from something but there's no JavaScript in the repository so I'm guessing it's wrong.

After removing this from my lazy config, it seems to fix the installation error and your plugin still works, so I've gone ahead and removed it from all of the build instructions. I haven't tested it in anything but lazy, but it should work because they're all doing the same thing. Let me know if I'm misunderstanding something, but I hope this helps!